### PR TITLE
fix: add client_max_body_size and gzip on to nginx

### DIFF
--- a/cluster/config/nginx.conf
+++ b/cluster/config/nginx.conf
@@ -9,13 +9,21 @@ http {
     server core:8080 max_fails=3 fail_timeout=60s;
   }
 
+  gzip on; # Enables compression, incl Web API content-types
+  gzip_types
+    "application/json;charset=utf-8" application/json
+    "application/javascript;charset=utf-8" application/javascript text/javascript
+    "application/xml;charset=utf-8" application/xml text/xml
+    "text/css;charset=utf-8" text/css
+    "text/plain;charset=utf-8" text/plain;
+
   server {
     listen 80;
     port_in_redirect off;
 
     root /data/apps;
 
-    rewrite ^/$ http://$http_host/dhis-web-dashboard redirect;
+    client_max_body_size 10m;
 
     location / {
       include mime.types;


### PR DESCRIPTION
Align closer to the best practices of DHIS2 deployments: https://docs.dhis2.org/master/en/implementer/html/dhis2_implementation_guide_full.html#install_basic_nginx_setup