### PR TITLE
fix: re-add redirect from / to /dhis-web-dashboard

### DIFF
--- a/cluster/config/nginx.conf
+++ b/cluster/config/nginx.conf
@@ -24,6 +24,9 @@ http {
     root /data/apps;
 
     client_max_body_size 10m;
+    
+    # Redirect required to prevent 403 error on / access
+    rewrite ^/$ $scheme://$http_host/dhis-web-dashboard redirect;
 
     location / {
       include mime.types;


### PR DESCRIPTION
Still need to investigate why this is needed, but it's definitely needed.