### PR TITLE
refactor: use postgres-contrib image

### DIFF
--- a/app-hub/docker-compose.yml
+++ b/app-hub/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - db
     env_file: .apphub.env
   db:
-    build: ./postgres-uuid
+    image: dhis2/postgres-contrib
     restart: unless-stopped
     environment:
        POSTGRES_DB: app-hub

--- a/app-hub/postgres-uuid/Dockerfile
+++ b/app-hub/postgres-uuid/Dockerfile
@@ -1,7 +1,0 @@
-FROM postgres:latest
-
-RUN apt-get update && apt-get install -y postgresql-contrib
-
-COPY createExtension.sh /docker-entrypoint-initdb.d/
-
-RUN chmod 755 /docker-entrypoint-initdb.d/createExtension.sh

--- a/app-hub/postgres-uuid/createExtension.sh
+++ b/app-hub/postgres-uuid/createExtension.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname="$POSTGRES_DB"<<-EOSQL
-   CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-EOSQL


### PR DESCRIPTION
Uses the image generated from: https://github.com/dhis2/postgres-contrib

The postgres-contrib repo builds and publishes to Docker Hub in three situations:

- A commit is pushed to `master`
- A release is created either through a tag or the GitHub interface
- Monthly on the first day of the month

This image turned out to be necessary as we use the database image when running the tests in the app-hub Docker image.

Relates to: https://github.com/dhis2/app-hub/pull/238