### PR TITLE
fix: set DHIS2_HOME env var to /DHIS2_home for images pre-Jib TECH-1433

### DIFF
--- a/cluster/config/DHIS2_home/log4j2.xml
+++ b/cluster/config/DHIS2_home/log4j2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="10">
+    <!-- Stream logs:
+            docker compose logs -f web
+         Stream logs of a particuar package only:
+            docker compose logs -f web | grep org.hisp.dhis.monitoring.metrics
+         Show timestamps:
+            docker compose logs -t -f web
+    -->
+    <Properties>
+        <Property name="layout">%-5level %c [%t] %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${layout}" />
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <!--
+            This config logs events
+
+            for Loggers in packages starting from "org.hips.dhis" below i.e. "org.hisp.security"
+            from level INFO to more severe (WARN, ERROR, ...)
+
+            any Logger without a config here will log from level WARN to more severe.
+
+            Adapt this config as you see fit.
+
+            Please check https://logging.apache.org/log4j/2.x/manual/configuration.html
+        -->
+        <Logger name="org.hisp.dhis" level="INFO" additivity="true"/>
+
+        <Root level="WARN">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/cluster/config/DHIS2_home/log4j2.xml
+++ b/cluster/config/DHIS2_home/log4j2.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN" monitorInterval="10">
     <!-- Stream logs:
-            docker compose logs -f web
+            docker compose logs -f core
          Stream logs of a particuar package only:
-            docker compose logs -f web | grep org.hisp.dhis.monitoring.metrics
+            docker compose logs -f core | grep org.hisp.dhis.monitoring.metrics
          Show timestamps:
-            docker compose logs -t -f web
+            docker compose logs -t -f core
     -->
     <Properties>
         <Property name="layout">%-5level %c [%t] %msg%n</Property>

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     volumes:
       - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/opt/dhis2}/dhis.conf:ro
       - ./config/server.xml:/usr/local/tomcat/conf/server.xml
-      - ./config/DHIS2_home:${DHIS2_HOME:-/opt/dhis2}
     environment:
       DHIS2_HOME: ${DHIS2_HOME:-/opt/dhis2}
       CATALINA_OPTS: "-Dcontext.path='${DHIS2_CORE_CONTEXT_PATH:-}'"

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     restart: always
     volumes:
       - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/DHIS2_home}/dhis.conf
-      - ./config/DHIS2_home/log4j2.xml:/opt/dhis2/log4j2.xml
+      - ./config/DHIS2_home/log4j2.xml:${DHIS2_HOME:-/DHIS2_home}/log4j2.xml
       - ./config/server.xml:/usr/local/tomcat/conf/server.xml
     environment:
       DHIS2_HOME: ${DHIS2_HOME:-/DHIS2_home}
       CATALINA_OPTS: "-Dcontext.path='${DHIS2_CORE_CONTEXT_PATH:-}' \
-              -Dlog4j2.configurationFile=/opt/dhis2/log4j2.xml"
+              -Dlog4j2.configurationFile=${DHIS2_HOME:-/DHIS2_home}/log4j2.xml"
     depends_on:
       - "db"
   db:

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: "${DHIS2_CORE_IMAGE}"
     restart: always
     volumes:
-      - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/opt/dhis2}/dhis.conf:ro
+      - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/DHIS2_home}/dhis.conf:ro
       - ./config/server.xml:/usr/local/tomcat/conf/server.xml
     environment:
-      DHIS2_HOME: ${DHIS2_HOME:-/opt/dhis2}
+      DHIS2_HOME: ${DHIS2_HOME:-/DHIS2_home}
       CATALINA_OPTS: "-Dcontext.path='${DHIS2_CORE_CONTEXT_PATH:-}'"
     depends_on:
       - "db"

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: "${DHIS2_CORE_IMAGE}"
     restart: always
     volumes:
-      - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/DHIS2_home}/dhis.conf:ro
-      - ./config/DHIS2_home/log4j2.xml:/opt/dhis2/log4j2.xml:ro
+      - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/DHIS2_home}/dhis.conf
+      - ./config/DHIS2_home/log4j2.xml:/opt/dhis2/log4j2.xml
       - ./config/server.xml:/usr/local/tomcat/conf/server.xml
     environment:
       DHIS2_HOME: ${DHIS2_HOME:-/DHIS2_home}

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/DHIS2_home}/dhis.conf
       - ./config/DHIS2_home/log4j2.xml:${DHIS2_HOME:-/DHIS2_home}/log4j2.xml
       - ./config/server.xml:/usr/local/tomcat/conf/server.xml
+      - home:${DHIS2_HOME:-/DHIS2_home}
     environment:
       DHIS2_HOME: ${DHIS2_HOME:-/DHIS2_home}
       CATALINA_OPTS: "-Dcontext.path='${DHIS2_CORE_CONTEXT_PATH:-}' \

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -5,10 +5,12 @@ services:
     restart: always
     volumes:
       - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/DHIS2_home}/dhis.conf:ro
+      - ./config/DHIS2_home/log4j2.xml:/opt/dhis2/log4j2.xml:ro
       - ./config/server.xml:/usr/local/tomcat/conf/server.xml
     environment:
       DHIS2_HOME: ${DHIS2_HOME:-/DHIS2_home}
-      CATALINA_OPTS: "-Dcontext.path='${DHIS2_CORE_CONTEXT_PATH:-}'"
+      CATALINA_OPTS: "-Dcontext.path='${DHIS2_CORE_CONTEXT_PATH:-}' \
+              -Dlog4j2.configurationFile=/opt/dhis2/log4j2.xml"
     depends_on:
       - "db"
   db:

--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -4,11 +4,11 @@ services:
     image: "${DHIS2_CORE_IMAGE}"
     restart: always
     volumes:
-      - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:/DHIS2_home/dhis.conf
+      - ${DHIS2_CORE_CONFIG:-./config/DHIS2_home/dhis.conf}:${DHIS2_HOME:-/opt/dhis2}/dhis.conf:ro
       - ./config/server.xml:/usr/local/tomcat/conf/server.xml
-      - ./config/DHIS2_home:/DHIS2_home
+      - ./config/DHIS2_home:${DHIS2_HOME:-/opt/dhis2}
     environment:
-      DHIS2_HOME: /DHIS2_home
+      DHIS2_HOME: ${DHIS2_HOME:-/opt/dhis2}
       CATALINA_OPTS: "-Dcontext.path='${DHIS2_CORE_CONTEXT_PATH:-}'"
     depends_on:
       - "db"


### PR DESCRIPTION
See https://github.com/dhis2/cli/pull/586 for details on these changes.

By passing a `log4j2configFile` we turn off logging to files. The config has hot-reloading enabled `monitorInterval="10"`. So devs can adjust it and see their changes reflected in how DHIS2 logs. 

The configuration is minimal and based on what we do in [core (without the file logging business)](https://github.com/dhis2/dhis2-core/blob/log4j2-xml-only/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/WEB-INF/classes/log4j2.xml).

You can easily follow the logs of a particular package/class. The following shows logs triggered by logging in and out of DHIS2.

```sh
docker compose logs --follow core | grep org.hisp.dhis.security

core-web-1  | INFO  org.hisp.dhis.security.AuthenticationLoggerListener [http-nio-8080-exec-6] Authentication event: AuthenticationSuccessEvent; username: admin; ip: 192.168.96.1; sessionId: 32966e562fa80b2c6187ac213e5518ae93fed8fad82409ead4b555a04bf43322
core-web-1  | INFO  org.hisp.dhis.security.AuthenticationLoggerListener [http-nio-8080-exec-3] Authentication event: LogoutSuccessEvent; username: admin; ip: 192.168.96.1; sessionId: 32966e562fa80b2c6187ac213e5518ae93fed8fad82409ead4b555a04bf43322
```

with timestamps

```sh
docker compose logs --timestamps --follow core | grep org.hisp.dhis.security
```

or using d2

```sh
d2 cluster logs test-2.39.0 core | grep org.hisp.dhis.security
```