### PR TITLE
feat: use arm compatible DB image

### DIFF
--- a/cluster/docker-compose.yml
+++ b/cluster/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - "db"
   db:
-    image: "mdillon/postgis:10-alpine"
+    image: ghcr.io/baosystems/postgis:12-3.3
     command: "postgres -c max_locks_per_transaction=100"
     restart: always
     volumes:


### PR DESCRIPTION
its the same image we currently use in core as the official postgis image does not yet provide arm compatible images.

see https://github.com/dhis2/dhis2-core/blob/cd279670d9b47c8d1ede6cb8e5bd26bb78c7faac/docker-compose.yml#L24